### PR TITLE
fix: close issue #39 - update bid status to inactive after order creation

### DIFF
--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -34,6 +34,7 @@ export class OrderService {
       ...rest,
     });
 
+    this.bidService.deactivateBid(bidId);
     return await this.orderRepository.save(newOrder);
   }
 


### PR DESCRIPTION
- Ensure bid status is set to inactive once an order is created on that bid.