### PR TITLE
feat(bid): add endpoint to retrieve bid by moduleId and moduleType

### DIFF
--- a/src/bid/bid.controller.ts
+++ b/src/bid/bid.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, HttpStatus, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, HttpStatus, NotFoundException, Param, Post, Put, Query, UseGuards } from '@nestjs/common';
 import { GetUser, JwtAuthGuard } from '../auth';
 import { STATUS } from '../common';
 import { ApiResponseDto } from '../common/dto/api-response.dto';
@@ -127,5 +127,22 @@ export class BidController {
   ): Promise<ApiResponseDto<BidResponse>> {
     const response = await this.bidService.rejectBidResponse(responseId, user.user_id);
     return ApiResponseDto.success(HttpStatus.OK, 'Bid response rejected successfully', response);
+  }
+
+  // Get bid by moduleId and moduleType
+  @Get('/module/:moduleId')
+  async getBidByModuleId(
+    @Param('moduleId') moduleId: number,
+    @Query('moduleType') moduleType: string
+  ): Promise<ApiResponseDto<Bid>> {
+    try {
+      const bid = await this.bidService.findBidByModuleId(moduleId, moduleType);
+      return ApiResponseDto.success(HttpStatus.OK, 'Bid retrieved successfully', bid);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        return ApiResponseDto.error(HttpStatus.NOT_FOUND, error.message, null);
+      }
+      throw error;
+    }
   }
 }

--- a/src/bid/bid.service.ts
+++ b/src/bid/bid.service.ts
@@ -349,4 +349,21 @@ export class BidService {
 
     return this.bidResponseRepository.save(response);
   }
+
+  // Find bid by moduleId and moduleType
+  async findBidByModuleId(moduleId: number, moduleType: string): Promise<Bid> {
+    const bid = await this.bidRepository.findOne({
+      where: {
+        module_id: moduleId,
+        module_type: moduleType
+      },
+      relations: ['responses', 'responses.manufacturer'],
+    });
+
+    if (!bid) {
+      throw new NotFoundException(`Bid with moduleId ${moduleId} and type ${moduleType} not found`);
+    }
+
+    return bid;
+  }
 }

--- a/src/bid/dto/update-bid.dto.ts
+++ b/src/bid/dto/update-bid.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsDecimal, IsIn, IsNumberString } from 'class-validator';
+import { IsString, IsOptional, IsDecimal, IsIn, IsNumberString, IsNumber } from 'class-validator';
 import { STATUS } from 'common';
 
 export class UpdateBidDto {
@@ -11,7 +11,7 @@ export class UpdateBidDto {
   description?: string;
 
   @IsOptional()
-  @IsNumberString()  // Allowing the price to be sent as a string
+  @IsNumber()
   price?: number;  // Change price to string for validation purposes
 
   @IsOptional()


### PR DESCRIPTION
- Implemented `getBidByModuleId` in `BidController` to fetch bids based on module ID and type.
- Added `findBidByModuleId` method in `BidService` to handle the retrieval logic with error handling for not found cases.
- Updated `UpdateBidDto` to change price validation from string to number for better data integrity.